### PR TITLE
- Add detection and handling of Node.js PKCS1 support within the plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ src/plugin/version.ts
 src/version.ts
 
 TODO
+.idea

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/homebridge-eufy-security/plugin/issues"
   },
   "engines": {
-    "node": "20.11.0 || ^22",
+    "node": "20.11.0 || ^22 || ^24",
     "homebridge": "^1.9.0 || ^2.0.0 || ^2.0.0-beta.27 || ^2.0.0-alpha.37"
   },
   "main": "dist/index.js",

--- a/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.html
+++ b/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.html
@@ -8,7 +8,15 @@
     </div>
   </div>
 
-  <small><i>
-      Starting from Node.js versions 18.19.1, 20.11.1, and 21.6.2, the removal of RSA_PKCS1_PADDING support breaks Eufy Security's livestream/P2P functionality. We've developed a countermeasure based on software calculation, it will be 10x times less effective than hardware but it can make some cameras work on Node.js 22+. <a href="https://github.com/homebridge-eufy-security/plugin/wiki/Node.js-Compatibility-with-Eufy-Security-Plugin" target="_blank">More technical details here</a>.
-    </i></small>
+    <div class="mb-2" *ngIf="nodeVersion && opensslVersion">
+      <small class="text-muted">
+        <strong>Current Environment:</strong> Node.js {{nodeVersion}}, OpenSSL {{opensslVersion}}
+        <span *ngIf="nativePKCS1Support" class="badge bg-success ms-2">Native PKCS1 Support Available</span>
+        <span *ngIf="!nativePKCS1Support" class="badge bg-warning ms-2">Native PKCS1 Support Not Available</span>
+      </small>
+    </div>
+    
+    <small><i>
+        Starting from Node.js versions 18.19.1, 20.11.1, and 21.6.2, the removal of RSA_PKCS1_PADDING support broke Eufy Security's livestream/P2P functionality. However, <strong>Node.js 24.9.0+ with OpenSSL 3.5.2+</strong> has restored native PKCS1 support. If you're using one of these newer versions, you can disable this setting for better performance. For older affected versions, we've developed a countermeasure based on software calculation, though it will be 10x less effective than hardware but can make cameras work. <a href="https://github.com/homebridge-eufy-security/plugin/wiki/Node.js-Compatibility-with-Eufy-Security-Plugin" target="_blank">More technical details here</a>.
+      </i></small>
 </div>

--- a/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.ts
+++ b/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.ts
@@ -29,89 +29,14 @@ export class EmbeddedPKCS1SupportComponent extends ConfigOptionsInterpreter impl
   
   private async detectNodeVersions(): Promise<void> {
     try {
-      // Get Node.js and OpenSSL versions from the server
-      const versions = await this.pluginService.getNodeVersions();
-      this.nodeVersion = versions.node || 'Unknown';
-      this.opensslVersion = versions.openssl || 'Unknown';
-      this.nativePKCS1Support = this.hasNativePKCS1Support(versions.node, versions.openssl);
+      // Get Node.js and OpenSSL versions and PKCS1 support status from the server
+      const versionInfo = await this.pluginService.getNodeVersions();
+      this.nodeVersion = versionInfo.node || 'Unknown';
+      this.opensslVersion = versionInfo.openssl || 'Unknown';
+      this.nativePKCS1Support = versionInfo.nativePKCS1Support || false;
     } catch (error) {
       console.warn('Could not detect Node.js versions:', error);
     }
-  }
-  
-  private hasNativePKCS1Support(nodeVersion: string, opensslVersion: string): boolean {
-    if (!nodeVersion || !opensslVersion) {
-      return false;
-    }
-    
-    // Parse Node.js version
-    const nodeVersionMatch = nodeVersion.match(/^v?(\d+)\.(\d+)\.(\d+)/);
-    if (!nodeVersionMatch) {
-      return false;
-    }
-    
-    const nodeMajor = parseInt(nodeVersionMatch[1], 10);
-    const nodeMinor = parseInt(nodeVersionMatch[2], 10);
-    const nodePatch = parseInt(nodeVersionMatch[3], 10);
-    
-    // Parse OpenSSL version
-    const opensslVersionMatch = opensslVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
-    if (!opensslVersionMatch) {
-      return false;
-    }
-    
-    const opensslMajor = parseInt(opensslVersionMatch[1], 10);
-    const opensslMinor = parseInt(opensslVersionMatch[2], 10);
-    const opensslPatch = parseInt(opensslVersionMatch[3], 10);
-    
-    // Node.js 24.9.0+ with OpenSSL 3.5.2+ has restored PKCS1 support
-    if (nodeMajor >= 25) {
-      return true;
-    }
-    
-    if (nodeMajor === 24 && nodeMinor >= 9) {
-      // Check if OpenSSL is 3.5.2+
-      if (opensslMajor > 3) {
-        return true;
-      }
-      if (opensslMajor === 3 && opensslMinor > 5) {
-        return true;
-      }
-      if (opensslMajor === 3 && opensslMinor === 5 && opensslPatch >= 2) {
-        return true;
-      }
-    }
-    
-    // Versions before the PKCS1 removal had native support
-    if (nodeMajor < 18) {
-      return true;
-    }
-    
-    if (nodeMajor === 18 && nodeMinor < 19) {
-      return true;
-    }
-    
-    if (nodeMajor === 18 && nodeMinor === 19 && nodePatch < 1) {
-      return true;
-    }
-    
-    if (nodeMajor === 20 && nodeMinor < 11) {
-      return true;
-    }
-    
-    if (nodeMajor === 20 && nodeMinor === 11 && nodePatch < 1) {
-      return true;
-    }
-    
-    if (nodeMajor === 21 && nodeMinor < 6) {
-      return true;
-    }
-    
-    if (nodeMajor === 21 && nodeMinor === 6 && nodePatch < 2) {
-      return true;
-    }
-    
-    return false;
   }
 
   /** Customize from here */

--- a/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.ts
+++ b/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { PluginService } from '../../plugin.service';
 import { ConfigOptionsInterpreter } from '../config-options-interpreter';
 import { FormsModule } from '@angular/forms';
@@ -8,11 +9,14 @@ import { DEFAULT_CONFIG_VALUES } from '../../util/default-config-values';
   selector: 'app-embedded-pkcs1-support',
   templateUrl: './embedded-pkcs1-support.component.html',
   standalone: true,
-  imports: [FormsModule],
+  imports: [CommonModule, FormsModule],
 })
 export class EmbeddedPKCS1SupportComponent extends ConfigOptionsInterpreter implements OnInit {
 
   enableEmbeddedPKCS1Support = DEFAULT_CONFIG_VALUES.enableEmbeddedPKCS1Support;
+  nodeVersion: string = '';
+  opensslVersion: string = '';
+  nativePKCS1Support: boolean = false;
 
   constructor(pluginService: PluginService) {
     super(pluginService);
@@ -20,6 +24,94 @@ export class EmbeddedPKCS1SupportComponent extends ConfigOptionsInterpreter impl
   
   async ngOnInit(): Promise<void> {
     this.readValue();
+    await this.detectNodeVersions();
+  }
+  
+  private async detectNodeVersions(): Promise<void> {
+    try {
+      // Get Node.js and OpenSSL versions from the server
+      const versions = await this.pluginService.getNodeVersions();
+      this.nodeVersion = versions.node || 'Unknown';
+      this.opensslVersion = versions.openssl || 'Unknown';
+      this.nativePKCS1Support = this.hasNativePKCS1Support(versions.node, versions.openssl);
+    } catch (error) {
+      console.warn('Could not detect Node.js versions:', error);
+    }
+  }
+  
+  private hasNativePKCS1Support(nodeVersion: string, opensslVersion: string): boolean {
+    if (!nodeVersion || !opensslVersion) {
+      return false;
+    }
+    
+    // Parse Node.js version
+    const nodeVersionMatch = nodeVersion.match(/^v?(\d+)\.(\d+)\.(\d+)/);
+    if (!nodeVersionMatch) {
+      return false;
+    }
+    
+    const nodeMajor = parseInt(nodeVersionMatch[1], 10);
+    const nodeMinor = parseInt(nodeVersionMatch[2], 10);
+    const nodePatch = parseInt(nodeVersionMatch[3], 10);
+    
+    // Parse OpenSSL version
+    const opensslVersionMatch = opensslVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (!opensslVersionMatch) {
+      return false;
+    }
+    
+    const opensslMajor = parseInt(opensslVersionMatch[1], 10);
+    const opensslMinor = parseInt(opensslVersionMatch[2], 10);
+    const opensslPatch = parseInt(opensslVersionMatch[3], 10);
+    
+    // Node.js 24.9.0+ with OpenSSL 3.5.2+ has restored PKCS1 support
+    if (nodeMajor >= 25) {
+      return true;
+    }
+    
+    if (nodeMajor === 24 && nodeMinor >= 9) {
+      // Check if OpenSSL is 3.5.2+
+      if (opensslMajor > 3) {
+        return true;
+      }
+      if (opensslMajor === 3 && opensslMinor > 5) {
+        return true;
+      }
+      if (opensslMajor === 3 && opensslMinor === 5 && opensslPatch >= 2) {
+        return true;
+      }
+    }
+    
+    // Versions before the PKCS1 removal had native support
+    if (nodeMajor < 18) {
+      return true;
+    }
+    
+    if (nodeMajor === 18 && nodeMinor < 19) {
+      return true;
+    }
+    
+    if (nodeMajor === 18 && nodeMinor === 19 && nodePatch < 1) {
+      return true;
+    }
+    
+    if (nodeMajor === 20 && nodeMinor < 11) {
+      return true;
+    }
+    
+    if (nodeMajor === 20 && nodeMinor === 11 && nodePatch < 1) {
+      return true;
+    }
+    
+    if (nodeMajor === 21 && nodeMinor < 6) {
+      return true;
+    }
+    
+    if (nodeMajor === 21 && nodeMinor === 6 && nodePatch < 2) {
+      return true;
+    }
+    
+    return false;
   }
 
   /** Customize from here */

--- a/src/configui/app/plugin.service.ts
+++ b/src/configui/app/plugin.service.ts
@@ -133,4 +133,19 @@ export class PluginService extends EventTarget {
       console.log('There was an error when reseting config: ', error);
     }
   }
+
+  /**
+   * Gets the current Node.js and OpenSSL versions from the server.
+   * 
+   * @returns A Promise that resolves with version information.
+   */
+  public async getNodeVersions(): Promise<{ node: string; openssl: string }> {
+    try {
+      const versions = await window.homebridge.request('/nodeVersions');
+      return versions;
+    } catch (error) {
+      console.log('There was an error getting Node.js versions: ', error);
+      return { node: '', openssl: '' };
+    }
+  }
 }

--- a/src/configui/app/plugin.service.ts
+++ b/src/configui/app/plugin.service.ts
@@ -139,13 +139,13 @@ export class PluginService extends EventTarget {
    * 
    * @returns A Promise that resolves with version information.
    */
-  public async getNodeVersions(): Promise<{ node: string; openssl: string }> {
+  public async getNodeVersions(): Promise<{ node: string; openssl: string; nativePKCS1Support: boolean }> {
     try {
       const versions = await window.homebridge.request('/nodeVersions');
       return versions;
     } catch (error) {
       console.log('There was an error getting Node.js versions: ', error);
-      return { node: '', openssl: '' };
+      return { node: '', openssl: '', nativePKCS1Support: false };
     }
   }
 }

--- a/src/plugin/utils/pkcs1-support.ts
+++ b/src/plugin/utils/pkcs1-support.ts
@@ -21,6 +21,11 @@ export function hasNativePKCS1Support(): boolean {
   const nodeMinor = parseInt(nodeVersionMatch[2], 10);
   const nodePatch = parseInt(nodeVersionMatch[3], 10);
   
+  // Handle missing OpenSSL version (should not happen in normal Node.js, but defensive programming)
+  if (!openSSLVersion) {
+    return false;
+  }
+  
   // Parse OpenSSL version
   const opensslVersionMatch = openSSLVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
   if (!opensslVersionMatch) {

--- a/src/plugin/utils/pkcs1-support.ts
+++ b/src/plugin/utils/pkcs1-support.ts
@@ -1,0 +1,104 @@
+/**
+ * Utility functions to detect Node.js PKCS1 support
+ */
+
+/**
+ * Check if the current Node.js version supports PKCS1 padding natively
+ * Node.js versions that removed PKCS1 support: 18.19.1+, 20.11.1+, 21.6.2+
+ * Node.js versions that restored PKCS1 support: 24.9.0+ (with OpenSSL 3.5.2+)
+ */
+export function hasNativePKCS1Support(): boolean {
+  const nodeVersion = process.version;
+  const openSSLVersion = process.versions.openssl;
+  
+  // Parse Node.js version
+  const nodeVersionMatch = nodeVersion.match(/^v(\d+)\.(\d+)\.(\d+)/);
+  if (!nodeVersionMatch) {
+    return false;
+  }
+  
+  const nodeMajor = parseInt(nodeVersionMatch[1], 10);
+  const nodeMinor = parseInt(nodeVersionMatch[2], 10);
+  const nodePatch = parseInt(nodeVersionMatch[3], 10);
+  
+  // Parse OpenSSL version
+  const opensslVersionMatch = openSSLVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!opensslVersionMatch) {
+    return false;
+  }
+  
+  const opensslMajor = parseInt(opensslVersionMatch[1], 10);
+  const opensslMinor = parseInt(opensslVersionMatch[2], 10);
+  const opensslPatch = parseInt(opensslVersionMatch[3], 10);
+  
+  // Node.js 24.9.0+ with OpenSSL 3.5.2+ has restored PKCS1 support
+  if (nodeMajor >= 25) {
+    return true;
+  }
+  
+  if (nodeMajor === 24 && nodeMinor >= 9) {
+    // Check if OpenSSL is 3.5.2+
+    if (opensslMajor > 3) {
+      return true;
+    }
+    if (opensslMajor === 3 && opensslMinor > 5) {
+      return true;
+    }
+    if (opensslMajor === 3 && opensslMinor === 5 && opensslPatch >= 2) {
+      return true;
+    }
+  }
+  
+  // Versions before the PKCS1 removal had native support
+  if (nodeMajor < 18) {
+    return true;
+  }
+  
+  if (nodeMajor === 18 && nodeMinor < 19) {
+    return true;
+  }
+  
+  if (nodeMajor === 18 && nodeMinor === 19 && nodePatch < 1) {
+    return true;
+  }
+  
+  if (nodeMajor === 20 && nodeMinor < 11) {
+    return true;
+  }
+  
+  if (nodeMajor === 20 && nodeMinor === 11 && nodePatch < 1) {
+    return true;
+  }
+  
+  if (nodeMajor === 21 && nodeMinor < 6) {
+    return true;
+  }
+  
+  if (nodeMajor === 21 && nodeMinor === 6 && nodePatch < 2) {
+    return true;
+  }
+  
+  // For versions that removed PKCS1 support but haven't restored it
+  return false;
+}
+
+/**
+ * Get the list of problematic Node.js versions that removed PKCS1 support
+ */
+export function getProblematicNodeVersions(): string[] {
+  return ['18.19.1+', '20.11.1+', '21.6.2+', '22.x.x', '23.x.x'];
+}
+
+/**
+ * Check if embedded PKCS1 support should be automatically enabled
+ * based on the current Node.js and OpenSSL versions
+ */
+export function shouldEnableEmbeddedPKCS1(manualOverride?: boolean): boolean {
+  // If user has manually set the override, respect it
+  if (manualOverride !== undefined) {
+    return manualOverride;
+  }
+  
+  // If native PKCS1 support is available, don't use embedded support
+  return !hasNativePKCS1Support();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,6 +108,7 @@ class UiServer {
     this.onRequest('/storedAccessories', this.loadStoredAccessories.bind(this));
     this.onRequest('/reset', this.resetPlugin.bind(this));
     this.onRequest('/downloadLogs', this.downloadLogs.bind(this));
+    this.onRequest('/nodeVersions', this.getNodeVersions.bind(this));
   }
 
   /**
@@ -459,6 +460,26 @@ class UiServer {
       return true;
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * Gets the current Node.js and OpenSSL versions.
+   * 
+   * @returns An object containing Node.js and OpenSSL versions.
+   */
+  async getNodeVersions(): Promise<{ node: string; openssl: string }> {
+    try {
+      return {
+        node: process.version,
+        openssl: process.versions.openssl || 'Unknown'
+      };
+    } catch (error) {
+      this.log.error('Error getting Node.js versions:', error);
+      return {
+        node: 'Unknown',
+        openssl: 'Unknown'
+      };
     }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -468,17 +468,22 @@ class UiServer {
    * 
    * @returns An object containing Node.js and OpenSSL versions.
    */
-  async getNodeVersions(): Promise<{ node: string; openssl: string }> {
+  async getNodeVersions(): Promise<{ node: string; openssl: string; nativePKCS1Support: boolean }> {
     try {
+      // Import the PKCS1 support utility
+      const { hasNativePKCS1Support } = await import('./plugin/utils/pkcs1-support.js');
+      
       return {
         node: process.version,
-        openssl: process.versions.openssl || 'Unknown'
+        openssl: process.versions.openssl || 'Unknown',
+        nativePKCS1Support: hasNativePKCS1Support()
       };
     } catch (error) {
       this.log.error('Error getting Node.js versions:', error);
       return {
         node: 'Unknown',
-        openssl: 'Unknown'
+        openssl: 'Unknown',
+        nativePKCS1Support: false
       };
     }
   }


### PR DESCRIPTION
- Introduce utility functions to check for native PKCS1 support based on Node.js and OpenSSL versions.
- Update `server.ts` and `plugin.service.ts` to expose Node.js and OpenSSL version information.
- Add environment details and dynamic recommendations in `embedded-pkcs1-support.component`.
- Update Node.js version constraints in `package.json`.
- Minor `.gitignore` update to exclude `.idea` directory.
This pull request introduces comprehensive improvements to PKCS1 support detection and configuration throughout the plugin, aiming to better handle Node.js and OpenSSL compatibility issues and guide users to optimal settings. The changes add robust version checks, update user-facing messages, and enhance debugging information, ensuring the plugin adapts to both older and newer Node.js releases that affect PKCS1 padding support.

**PKCS1 Support Detection and Configuration**

* Added a new utility module `pkcs1-support.ts` with functions to detect native PKCS1 support, list problematic Node.js versions, and determine if embedded support should be enabled. These are now used in both the platform and livestream manager logic.
* Updated `platform.ts` to log detailed Node.js and OpenSSL version info, warn users if their configuration is suboptimal, and clearly state whether native or embedded PKCS1 support is being used. [[1]](diffhunk://#diff-a4f0840c2d7234365fd3371d8f18a1622495c71e2cc29b56f451a2209891005dR49) [[2]](diffhunk://#diff-a4f0840c2d7234365fd3371d8f18a1622495c71e2cc29b56f451a2209891005dR311-R329)

**Livestream Manager Enhancements**

* Improved error handling in `LocalLivestreamManager.ts` to check for native PKCS1 support, log current environment details, and provide more accurate troubleshooting advice based on detected compatibility. [[1]](diffhunk://#diff-fcf0e3be7a9268c5e481b224e46f5fe3619fd44ca1eb868eeab5ef173479855fR5) [[2]](diffhunk://#diff-fcf0e3be7a9268c5e481b224e46f5fe3619fd44ca1eb868eeab5ef173479855fL83-R110)

**Config UI Improvements**

* The config UI now displays current Node.js and OpenSSL versions, detects PKCS1 support status, and updates help text to reflect restored support in Node.js 24.9.0+ with OpenSSL 3.5.2+. This helps users choose the best configuration for their environment. [[1]](diffhunk://#diff-21b18ab8e8c95ce764ce9c0d65d9c7ece0870f18ded525c11399ea40934b2268R11-R20) [[2]](diffhunk://#diff-2f3af569f816db7359b55fcb39542542a6d56264c83529fe7a4df1238127cb70R2) [[3]](diffhunk://#diff-2f3af569f816db7359b55fcb39542542a6d56264c83529fe7a4df1238127cb70L11-R114)

**Backend Support for Version Detection**

* Added a new `/nodeVersions` endpoint to the server and corresponding client-side service method, enabling the UI to fetch and display Node.js and OpenSSL versions for users. [[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R111) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R465-R484) [[3]](diffhunk://#diff-93ebf77cb1a939a1bdac51d10894de72c9cb5caa27c77439a0e0b5bbde2df5afR136-R150)

**Node.js Version Range Update**

* Updated the `package.json` to officially support Node.js 24.x in the engines field, reflecting compatibility with the latest versions that restore PKCS1 support.